### PR TITLE
Added script to detect faces of BFW 

### DIFF
--- a/code/python_scripts/bfw-detect-faces.py
+++ b/code/python_scripts/bfw-detect-faces.py
@@ -4,43 +4,17 @@ import cv2
 import pandas as pd
 from mtcnn import MTCNN
 
-dir_data = '../../data/bfw-data/samples/'
+dir_data = "../../data/bfw-data/samples/"
+obin = "../../data/bfw-data/detected-face-parts-5pt.pkl"
 imfiles = glob.glob(f"{dir_data}*males/n*/*.jpg")
 
 print(f"Running face detector on {len(imfiles)} images")
-# traingen= image_batch_generator(imfiles, batchsize=128)
-# detector = face_recognition.api.cnn_face_detector()
 
-
-# for _, img_path in tqdm(t):
-#     img = cv2.cvtColor(cv2.imread(img_path), cv2.COLOR_BGR2RGB)
-#     # img = face_recognition.load_image_file(img_path)
-#     # img_pil = Image.fromarray(img).convert("RGB")
-#     # img_pil = img_pil.resize(img_size)
-#     # img = cv2.resize(img,(img.shape[0]*2, img.shape[1]*2))
-#     # for img, impath in zip(imgs, img_paths):
-#
-#     faces_parts3.append((detector.detect_faces(img), img_path))
-#     # faces_parts3.append((face_recognition.face_landmarks(img), img_path))
 detector = MTCNN()
 faces_parts = {}
 for img_path in tqdm(imfiles):
     img = cv2.cvtColor(cv2.imread(img_path), cv2.COLOR_BGR2RGB)
-    # img = face_recognition.load_image_file(img_path)
-    # img_pil = Image.fromarray(img).convert("RGB")
-    # img_pil = img_pil.resize(img_size)
-    # for img, impath in zip(imgs, img_paths):
-    
-    faces_parts[img_path.replace(dir_data, '')] = detector.detect_faces(img)
-    # append((face_recognition.face_landmarks(img), img_path))
+    faces_parts[img_path.replace(dir_data, "")] = detector.detect_faces(img)
 
 
-pd.to_pickle(faces_parts, 'face-parts.pkl')
-# df = pd.DataFrame().from_dict(faces_parts)
-# pd.to(faces_parts, 'face-parts.pkl')
-# for batch in image_batch_generator(imfiles):
-#     pass
-
-
-# t=[f for f in faces_parts if not f[0]]
-
+pd.to_pickle(faces_parts, obin)


### PR DESCRIPTION
Uses the [mtcnn](https://github.com/ipazc/mtcnn) Python package, with defaults set as is.

A dictionary with <key-values> set as <filepath>-<mtcnn out>. Thus, each detection takes on the following output of a sample face:

```python
[
    {
        'box': [277, 90, 48, 63],
        'keypoints':
        {
            'nose': (303, 131),
            'mouth_right': (313, 141),
            'right_eye': (314, 114),
            'left_eye': (291, 117),
            'mouth_left': (296, 143)
        },
        'confidence': 0.99851983785629272
    }
]
```